### PR TITLE
Fix telegram import error in server script

### DIFF
--- a/controllers/inline_query_controller.py
+++ b/controllers/inline_query_controller.py
@@ -3,7 +3,8 @@ import os
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from telegram import InlineQueryResultArticle, InputTextMessageContent
-from telegram.ext import ContextTypes, Update
+from telegram import Update
+from telegram.ext import ContextTypes
 from services.search_service import JobSearchService
 from settings import Settings
 from logger import Logger


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update import path for `Update` class to resolve `ImportError`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `Update` class in `python-telegram-bot` version 20.x is now imported directly from the `telegram` package, not `telegram.ext`, which caused an `ImportError`. This PR adjusts the import statement accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ee64953-74d9-4323-a1b0-e897493ab861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ee64953-74d9-4323-a1b0-e897493ab861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>